### PR TITLE
Update GitHub Actions action versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "[gh-actions]"
+      include: scope

--- a/.github/workflows/handle-result.yaml
+++ b/.github/workflows/handle-result.yaml
@@ -10,13 +10,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: List files
         run: ls -R
 
       - name: Upload results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ github.ref_name}}
           path: |
@@ -31,7 +31,7 @@ jobs:
           git checkout ${{ github.ref_name }} -- '*.rc'
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: '^3.8'
 


### PR DESCRIPTION
We are currently using older versions of the updated GitHub Actions actions, and these older versions still use Node 12, [which is deprecated](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/).

This PR also configures Dependabot to create PRs updating workflows whenever a new version of a used action is released, as discussed in https://github.com/datalad/datalad-extensions/pull/105.